### PR TITLE
Fix typo error

### DIFF
--- a/ch09.md
+++ b/ch09.md
@@ -19,7 +19,7 @@ Event groups are another feature of FreeRTOS that allow events to be
 communicated to tasks. Unlike queues and semaphores:
 
 - Event groups allow a task to wait in the Blocked state for a
-  combination of one of more events to occur.
+  combination of one or more events to occur.
 
 - Event groups unblock all the tasks that were waiting for the same
   event, or combination of events, when the event occurs.


### PR DESCRIPTION
Minor typo fix in Chapter 9.1
Event groups allow a task to wait in the Blocked state for a combination of one or more events to occur

Description of changes:

of -> or

p.s. I have benefited greatly from this book, thanks!